### PR TITLE
Created printer configuration for Voron Zero

### DIFF
--- a/fullcontrol/gcode/printer_library/singletool/voron_zero.py
+++ b/fullcontrol/gcode/printer_library/singletool/voron_zero.py
@@ -7,7 +7,7 @@ def set_up(user_overrides: dict):
     '''
 
     # overrides for this specific printer relative those defined in base_settings.py
-    printer_overrides = {'primer': 'no_primer', 'chamber_temp': 50, 'z_offset': 0.0}
+    printer_overrides = {'primer': 'no_primer', 'chamber_temp': 50, 'z_offset': None, 'default_primer': True}
     # update default initialization settings with printer-specific overrides and user-defined overrides
     initialization_data = {**base_settings.default_initial_settings, **printer_overrides}
     initialization_data = {**initialization_data, **user_overrides}
@@ -24,25 +24,24 @@ def set_up(user_overrides: dict):
         text='M220 S' + str(initialization_data["print_speed_percent"])+' ; set speed factor override percentage'))
     starting_procedure_steps.append(ManualGcode(
         text='M221 S' + str(initialization_data["material_flow_percent"])+' ; set extrude factor override percentage'))
-    if initialization_data['z_offset']:
+    if initialization_data['z_offset'] is not None:
         starting_procedure_steps.append(ManualGcode(text='SET_GCODE_OFFSET Z=' + str(initialization_data['z_offset']) + ' MOVE=1'))
-    # starting_procedure_steps.append(Extruder(on=False))
-    # starting_procedure_steps.append(Point(x=5, y=5, z=10))
-    # starting_procedure_steps.append(StationaryExtrusion(volume=50, speed=250))
-    # starting_procedure_steps.append(Printer(travel_speed=250))
-    # starting_procedure_steps.append(Point(z=50))
-    # starting_procedure_steps.append(Printer(travel_speed=initialization_data["travel_speed"]))
-    # starting_procedure_steps.append(Point(x=10.0, y=10.0, z=0.3))
+    if initialization_data['default_primer']:
+        starting_procedure_steps.append(Extruder(on=False))
+        starting_procedure_steps.append(Point(x=5, y=5, z=10))
+        starting_procedure_steps.append(StationaryExtrusion(volume=50, speed=250))
+        starting_procedure_steps.append(Printer(travel_speed=250))
+        starting_procedure_steps.append(Point(z=50))
+        starting_procedure_steps.append(Printer(travel_speed=initialization_data["travel_speed"]))
+        starting_procedure_steps.append(Point(x=10.0, y=10.0, z=0.3))
     starting_procedure_steps.append(Extruder(on=True))
     starting_procedure_steps.append(ManualGcode(text=';-----\n; END OF STARTING PROCEDURE\n;-----\n'))
 
     ending_procedure_steps = []
     ending_procedure_steps.append(ManualGcode(text='\n;-----\n; START OF ENDING PROCEDURE\n;-----'))
     ending_procedure_steps.append(ManualGcode(text='print_end    ;end script from macro'))
-    ending_procedure_steps.append(ManualGcode(text='M221 S100 ; reset flow'))
     # ending_procedure_steps.append(ManualGcode(text='M900 K0 ; reset LA'))
-    ending_procedure_steps.append(ManualGcode(text='M84 ; disable steppers'))
-
+    
     initialization_data['starting_procedure_steps'] = starting_procedure_steps
     initialization_data['ending_procedure_steps'] = ending_procedure_steps
 

--- a/fullcontrol/gcode/printer_library/singletool/voron_zero.py
+++ b/fullcontrol/gcode/printer_library/singletool/voron_zero.py
@@ -40,7 +40,6 @@ def set_up(user_overrides: dict):
     ending_procedure_steps = []
     ending_procedure_steps.append(ManualGcode(text='\n;-----\n; START OF ENDING PROCEDURE\n;-----'))
     ending_procedure_steps.append(ManualGcode(text='print_end    ;end script from macro'))
-    # ending_procedure_steps.append(ManualGcode(text='M900 K0 ; reset LA'))
     
     initialization_data['starting_procedure_steps'] = starting_procedure_steps
     initialization_data['ending_procedure_steps'] = ending_procedure_steps

--- a/fullcontrol/gcode/printer_library/singletool/voron_zero.py
+++ b/fullcontrol/gcode/printer_library/singletool/voron_zero.py
@@ -40,7 +40,7 @@ def set_up(user_overrides: dict):
     ending_procedure_steps.append(ManualGcode(text='\n;-----\n; START OF ENDING PROCEDURE\n;-----'))
     ending_procedure_steps.append(ManualGcode(text='print_end    ;end script from macro'))
     ending_procedure_steps.append(ManualGcode(text='M221 S100 ; reset flow'))
-    ending_procedure_steps.append(ManualGcode(text='M900 K0 ; reset LA'))
+    # ending_procedure_steps.append(ManualGcode(text='M900 K0 ; reset LA'))
     ending_procedure_steps.append(ManualGcode(text='M84 ; disable steppers'))
 
     initialization_data['starting_procedure_steps'] = starting_procedure_steps

--- a/fullcontrol/gcode/printer_library/singletool/voron_zero.py
+++ b/fullcontrol/gcode/printer_library/singletool/voron_zero.py
@@ -1,0 +1,47 @@
+from fullcontrol.gcode import Point, Printer, Extruder, ManualGcode, PrinterCommand, GcodeComment, Buildplate, Hotend, Fan, StationaryExtrusion
+import fullcontrol.gcode.printer_library.singletool.base_settings as base_settings
+
+
+def set_up(user_overrides: dict):
+    ''' DO THIS
+    '''
+
+    # overrides for this specific printer relative those defined in base_settings.py
+    printer_overrides = {'primer': 'no_primer', 'chamber_temp': 50}
+    # update default initialization settings with printer-specific overrides and user-defined overrides
+    initialization_data = {**base_settings.default_initial_settings, **printer_overrides}
+    initialization_data = {**initialization_data, **user_overrides}
+
+    starting_procedure_steps = []
+    starting_procedure_steps.append(ManualGcode(
+        text='; Time to print!!!!!\n; GCode created with FullControl - tell us what you\'re printing!\n; info@fullcontrol.xyz or tag FullControlXYZ on Twitter/Instagram/LinkedIn/Reddit/TikTok \n'))
+    starting_procedure_steps.append(ManualGcode(text='print_start EXTRUDER=' + str(initialization_data["nozzle_temp"]) + ' BED='+str(initialization_data["bed_temp"]) + ' CHAMBER=' + str(initialization_data['chamber_temp'])))
+    starting_procedure_steps.append(PrinterCommand(id='absolute_coords'))
+    starting_procedure_steps.append(PrinterCommand(id='units_mm'))
+    starting_procedure_steps.append(Extruder(relative_gcode=initialization_data["relative_e"]))
+    starting_procedure_steps.append(Fan(speed_percent=initialization_data["fan_percent"]))
+    starting_procedure_steps.append(ManualGcode(
+        text='M220 S' + str(initialization_data["print_speed_percent"])+' ; set speed factor override percentage'))
+    starting_procedure_steps.append(ManualGcode(
+        text='M221 S' + str(initialization_data["material_flow_percent"])+' ; set extrude factor override percentage'))
+    # starting_procedure_steps.append(Extruder(on=False))
+    # starting_procedure_steps.append(Point(x=5, y=5, z=10))
+    # starting_procedure_steps.append(StationaryExtrusion(volume=50, speed=250))
+    # starting_procedure_steps.append(Printer(travel_speed=250))
+    # starting_procedure_steps.append(Point(z=50))
+    # starting_procedure_steps.append(Printer(travel_speed=initialization_data["travel_speed"]))
+    # starting_procedure_steps.append(Point(x=10.0, y=10.0, z=0.3))
+    starting_procedure_steps.append(Extruder(on=True))
+    starting_procedure_steps.append(ManualGcode(text=';-----\n; END OF STARTING PROCEDURE\n;-----\n'))
+
+    ending_procedure_steps = []
+    ending_procedure_steps.append(ManualGcode(text='\n;-----\n; START OF ENDING PROCEDURE\n;-----'))
+    ending_procedure_steps.append(ManualGcode(text='print_end    ;end script from macro'))
+    ending_procedure_steps.append(ManualGcode(text='M221 S100 ; reset flow'))
+    ending_procedure_steps.append(ManualGcode(text='M900 K0 ; reset LA'))
+    ending_procedure_steps.append(ManualGcode(text='M84 ; disable steppers'))
+
+    initialization_data['starting_procedure_steps'] = starting_procedure_steps
+    initialization_data['ending_procedure_steps'] = ending_procedure_steps
+
+    return initialization_data

--- a/fullcontrol/gcode/printer_library/singletool/voron_zero.py
+++ b/fullcontrol/gcode/printer_library/singletool/voron_zero.py
@@ -7,7 +7,7 @@ def set_up(user_overrides: dict):
     '''
 
     # overrides for this specific printer relative those defined in base_settings.py
-    printer_overrides = {'primer': 'no_primer', 'chamber_temp': 50}
+    printer_overrides = {'primer': 'no_primer', 'chamber_temp': 50, 'z_offset': 0.0}
     # update default initialization settings with printer-specific overrides and user-defined overrides
     initialization_data = {**base_settings.default_initial_settings, **printer_overrides}
     initialization_data = {**initialization_data, **user_overrides}
@@ -24,6 +24,8 @@ def set_up(user_overrides: dict):
         text='M220 S' + str(initialization_data["print_speed_percent"])+' ; set speed factor override percentage'))
     starting_procedure_steps.append(ManualGcode(
         text='M221 S' + str(initialization_data["material_flow_percent"])+' ; set extrude factor override percentage'))
+    if initialization_data['z_offset']:
+        starting_procedure_steps.append(ManualGcode(text='SET_GCODE_OFFSET Z=' + str(initialization_data['z_offset']) + ' MOVE=1'))
     # starting_procedure_steps.append(Extruder(on=False))
     # starting_procedure_steps.append(Point(x=5, y=5, z=10))
     # starting_procedure_steps.append(StationaryExtrusion(volume=50, speed=250))


### PR DESCRIPTION
I created a printer config to use Full Control with my Voron 0.1. It uses the print_start and print_end macros included in the klipper printer.cfg for the V0. It should work with all V0 versions. 
I did comment out the default priming blob as my print_start macro has a prime line included. I'm not sure what priming routine would be appropriate as the V0 has a very small bed. I'm open to ideas on that and happy to include it in my fork.
An optional z_offset setting was also added.