### PR TITLE
Fix Pydantic Versioning issue

### DIFF
--- a/fullcontrol/auxilliary_components.py
+++ b/fullcontrol/auxilliary_components.py
@@ -4,19 +4,19 @@ from fullcontrol.common import BaseModelPlus
 
 class Fan(BaseModelPlus):
     'fan speed percent (0-100)'
-    speed_percent: Optional[int]
+    speed_percent: Optional[int] = None
 
 
 class Hotend(BaseModelPlus):
     '''set temperature of hotend. if wait==True, system will wait for temperature to be reached
     before continuing. tool number can be defined for multi-tool printers
     '''
-    temp: Optional[int]
+    temp: Optional[int] = None
     wait: Optional[bool] = False
-    tool: Optional[int]
+    tool: Optional[int] = None
 
 
 class Buildplate(BaseModelPlus):
     'set temperature of the buildplate. if wait==True, system will wait for temperature to be reached before continuing'
-    temp: Optional[int]
+    temp: Optional[int] = None
     wait: Optional[bool] = False

--- a/fullcontrol/base.py
+++ b/fullcontrol/base.py
@@ -1,5 +1,5 @@
 
-from pydantic import BaseModel, root_validator
+from pydantic import model_validator, BaseModel
 
 
 class BaseModelPlus(BaseModel):
@@ -13,7 +13,8 @@ class BaseModelPlus(BaseModel):
             if (value is not None) and (key in self_vars):
                 self[key] = value
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def check_card_number_omitted(cls, values):
         annots = cls.__fields__
         for value in values:

--- a/fullcontrol/extrusion_classes.py
+++ b/fullcontrol/extrusion_classes.py
@@ -10,15 +10,15 @@ class ExtrusionGeometry(BaseModelPlus):
     manually). the 'area' attribute is automatically calculated unless area_model=='manual' 
     '''
     # area_model options: 'rectangle' / 'stadium' / 'circle' / 'manual':
-    area_model: Optional[str]
+    area_model: Optional[str] = None
     # width of printed line for area_model = rectangle or stadium:
-    width: Optional[float]
+    width: Optional[float] = None
     # height of printed line for area_model = rectangle or stadium:
-    height: Optional[float]
+    height: Optional[float] = None
     # diameter of printed line for area_model = circle:
-    diameter: Optional[float]
+    diameter: Optional[float] = None
     # automatically calculated based on area_model and relevant attributes
-    area: Optional[float]
+    area: Optional[float] = None
 
     def update_area(self) -> float:
         if self.area_model == "rectangle":
@@ -40,4 +40,4 @@ class StationaryExtrusion(BaseModelPlus):
 
 class Extruder(BaseModelPlus):
     'control whether extrusion is on or off'
-    on: Optional[bool]
+    on: Optional[bool] = None

--- a/fullcontrol/gcode/annotations.py
+++ b/fullcontrol/gcode/annotations.py
@@ -5,8 +5,8 @@ from pydantic import BaseModel
 class GcodeComment(BaseModel):
     '''use the 'text' attribute to add a comment as a new line gcode. use the 'end_of_previous_line_text' attribute 
     to add a comment to the end of the line of gcode produced by the previous step'''
-    text: Optional[str]
-    end_of_previous_line_text: Optional[str]
+    text: Optional[str] = None
+    end_of_previous_line_text: Optional[str] = None
 
     def gcode(self, state):
         'process this instance in a list of steps supplied by the designer to generate and return a line of gcode'

--- a/fullcontrol/gcode/commands.py
+++ b/fullcontrol/gcode/commands.py
@@ -5,7 +5,7 @@ from fullcontrol.common import BaseModelPlus
 
 class PrinterCommand(BaseModelPlus):
     'state the id of the printer command that should be executed ... manifesting in an appropriate line of gcode'
-    id: Optional[str]
+    id: Optional[str] = None
 
     def gcode(self, state):
         # this type of command can only be used after a Printer instance with commandlist has updated state.printer
@@ -14,7 +14,7 @@ class PrinterCommand(BaseModelPlus):
 
 class ManualGcode(BaseModelPlus):
     "custom gcode defined by 'text' attribute will be added as a new line of gcode"
-    text: Optional[str]
+    text: Optional[str] = None
 
     def gcode(self, state):
         'process this instance in a list of steps supplied by the designer to generate and return a line of gcode'

--- a/fullcontrol/gcode/extrusion_classes.py
+++ b/fullcontrol/gcode/extrusion_classes.py
@@ -44,16 +44,16 @@ class Extruder(BaseExtruder):
 
     # GCode attributes, used to translate the design into gcode:
     # units for E in GCode ... options: 'mm' / 'mm3'
-    units: Optional[str]
-    dia_feed: Optional[float]  # diameter of the feedstock filament
-    relative_gcode: Optional[bool]
+    units: Optional[str] = None
+    dia_feed: Optional[float] = None # diameter of the feedstock filament
+    relative_gcode: Optional[bool] = None
     # attibutes not set by user ... calculated automatically:
     # factor to convert volume of material into the value of 'E' in gcode
-    volume_to_e: Optional[float]
+    volume_to_e: Optional[float] = None
     # current extrusion volume for whole print
-    total_volume: Optional[float]
+    total_volume: Optional[float] = None
     # total extrusion volume reference value - this attribute is set to allow extrusion to be expressed relative to this point (for relative_gcode = True, it is reset for every line)
-    total_volume_ref: Optional[float]
+    total_volume_ref: Optional[float] = None
 
     def get_and_update_volume(self, volume):
         'DO THIS'

--- a/fullcontrol/gcode/printer.py
+++ b/fullcontrol/gcode/printer.py
@@ -5,9 +5,9 @@ from fullcontrol.common import Printer as BasePrinter
 
 class Printer(BasePrinter):
     'set print_speed and travel_speed of the 3D printer. see documentation for info about other attributes'
-    command_list: Optional[dict]
-    new_command: Optional[dict]
-    speed_changed: Optional[bool]
+    command_list: Optional[dict] = None
+    new_command: Optional[dict] = None
+    speed_changed: Optional[bool] = None
 
     def f_gcode(self, state):
         if self.speed_changed == True:

--- a/fullcontrol/gcode/state.py
+++ b/fullcontrol/gcode/state.py
@@ -17,10 +17,10 @@ class State(BaseModel):
     of various attributes
     '''
 
-    extruder: Optional[Extruder]
-    printer: Optional[Printer]
-    extrusion_geometry: Optional[ExtrusionGeometry]
-    steps: Optional[list]
+    extruder: Optional[Extruder] = None
+    printer: Optional[Printer] = None
+    extrusion_geometry: Optional[ExtrusionGeometry] = None
+    steps: Optional[list] = None
     point: Optional[Point] = Point()
     i: Optional[int] = 0
     gcode: Optional[list] = []

--- a/fullcontrol/geometry/vector.py
+++ b/fullcontrol/geometry/vector.py
@@ -4,6 +4,6 @@ from pydantic import BaseModel
 
 class Vector(BaseModel):
     'vector defined by x y and z distances'
-    x: Optional[float]
-    y: Optional[float]
-    z: Optional[float]
+    x: Optional[float] = None
+    y: Optional[float] = None
+    z: Optional[float] = None

--- a/fullcontrol/point.py
+++ b/fullcontrol/point.py
@@ -4,6 +4,6 @@ from fullcontrol.common import BaseModelPlus
 
 class Point(BaseModelPlus):
     'point with x y z cartesian components'
-    x: Optional[float]
-    y: Optional[float]
-    z: Optional[float]
+    x: Optional[float] = None
+    y: Optional[float] = None
+    z: Optional[float] = None

--- a/fullcontrol/printer.py
+++ b/fullcontrol/printer.py
@@ -5,5 +5,5 @@ from fullcontrol.common import BaseModelPlus
 class Printer(BaseModelPlus):
     'set print_speed and travel_speed of the 3D printer.'
 
-    print_speed: Optional[int]
-    travel_speed: Optional[int]
+    print_speed: Optional[int] = None
+    travel_speed: Optional[int] = None

--- a/fullcontrol/visualize/annotations.py
+++ b/fullcontrol/visualize/annotations.py
@@ -12,8 +12,8 @@ class PlotAnnotation(BaseModel):
     '''xyz point and label text to be shown on a plot. if the point is not defined, the 
     previous point in the list of steps before this annotation was defined is used
     '''
-    point: Optional[Point]
-    label: Optional[str]
+    point: Optional[Point] = None
+    label: Optional[str] = None
 
     def visualize(self, state: 'State', plot_data: 'PlotData', plot_controls: PlotControls):
         'process a PlotAnnotation in a list of steps supplied by the designer to update plot_data and state'

--- a/fullcontrol/visualize/bounding_box.py
+++ b/fullcontrol/visualize/bounding_box.py
@@ -6,20 +6,20 @@ from fullcontrol.common import Point
 
 class BoundingBox(BaseModel):
     'geometric measures of a bounding box, inlcuding mid values and ranges'
-    minx: Optional[float]
-    midx: Optional[float]
-    maxx: Optional[float]
+    minx: Optional[float] = None
+    midx: Optional[float] = None
+    maxx: Optional[float] = None
     # ranges and mid values are included as attributes, even though they are simple, to avoid them
     # being calculated for every point for the color_type z_gradient
-    rangex: Optional[float]
-    miny: Optional[float]
-    midy: Optional[float]
-    maxy: Optional[float]
-    rangey: Optional[float]
-    minz: Optional[float]
-    midz: Optional[float]
-    maxz: Optional[float]
-    rangez: Optional[float]
+    rangex: Optional[float] = None
+    miny: Optional[float] = None
+    midy: Optional[float] = None
+    maxy: Optional[float] = None
+    rangey: Optional[float] = None
+    minz: Optional[float] = None
+    midz: Optional[float] = None
+    maxz: Optional[float] = None
+    rangez: Optional[float] = None
 
     def calc_bounds(self, steps):
         'calculate the bounds and other useful geometric measures of the bounding box for all points in a list of steps'

--- a/fullcontrol/visualize/path.py
+++ b/fullcontrol/visualize/path.py
@@ -14,7 +14,7 @@ class Path(BaseModel):
     yvals: Optional[list] = []
     zvals: Optional[list] = []
     colors: Optional[list] = []  # [r,g,b]
-    extruder: Optional[Extruder]
+    extruder: Optional[Extruder] = None
     widths: Optional[list] = []
     heights: Optional[list] = []
 

--- a/fullcontrol/visualize/point.py
+++ b/fullcontrol/visualize/point.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 class Point(BasePoint):
     'generic fullcontrol Point with a color attribute and color/visualisation methods added'
-    color: Optional[list]  # [r,g,b]
+    color: Optional[list] = None  # [r,g,b]
 
     def visualize(self, state: 'State', plot_data: 'PlotData', plot_controls: PlotControls):
         'process a Point in a list of steps supplied by the designer to update plot_data and state'

--- a/fullcontrol/visualize/state.py
+++ b/fullcontrol/visualize/state.py
@@ -17,8 +17,8 @@ class State(BaseModel):
     extruder: Optional[Extruder] = Extruder(on=True)
     path_count_now: Optional[int] = 0
     point_count_now: Optional[int] = 0
-    point_count_total: Optional[int]
-    extrusion_geometry: Optional[ExtrusionGeometry]
+    point_count_total: Optional[int] = None
+    extrusion_geometry: Optional[ExtrusionGeometry] = None
 
     def count_points(self, steps: list):
         return sum(1 for step in steps if isinstance(step, Point))

--- a/lab/fullcontrol/multiaxis/gcode/XYZBC/point.py
+++ b/lab/fullcontrol/multiaxis/gcode/XYZBC/point.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 
 class Point(BasePoint):
     'generic gcode Point with 5-axis aspects added/modified'
-    b: Optional[float]
-    c: Optional[float]
+    b: Optional[float] = None
+    c: Optional[float] = None
 
     def XYZBC_gcode(self, self_systemXYZ, p) -> float:
         'generate XYZBC gcode string to move from a point p to this point. return XYZBC string'

--- a/lab/fullcontrol/multiaxis/gcode/XYZBC/printer.py
+++ b/lab/fullcontrol/multiaxis/gcode/XYZBC/printer.py
@@ -5,10 +5,10 @@ from fullcontrol.common import Point
 
 class Printer(BasePrinter):
     'generic gcode Printer with 5-axis aspects added/modified'
-    command_list: Optional[dict]
-    new_command: Optional[dict]
-    speed_changed: Optional[bool]
-    bc_intercept: Optional[Point]  # point of b-c axes intercept point in system coordinates
+    command_list: Optional[dict] = None
+    new_command: Optional[dict] = None
+    speed_changed: Optional[bool] = None
+    bc_intercept: Optional[Point]  = None # point of b-c axes intercept point in system coordinates
 
     def f_gcode(self, state):
         if self.speed_changed == True:

--- a/lab/fullcontrol/multiaxis/gcode/XYZBC/state.py
+++ b/lab/fullcontrol/multiaxis/gcode/XYZBC/state.py
@@ -19,10 +19,10 @@ class State(BaseModel):
     of various attributes
     '''
 
-    extruder: Optional[Extruder]
-    printer: Optional[Printer]
-    extrusion_geometry: Optional[ExtrusionGeometry]
-    steps: Optional[list]
+    extruder: Optional[Extruder] = None
+    printer: Optional[Printer] = None
+    extrusion_geometry: Optional[ExtrusionGeometry] = None
+    steps: Optional[list] = None
     point: Optional[Point] = Point()
     point_systemXYZ: Optional[Point] = Point()
     i: Optional[int] = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fullcontrol"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     { name="Andy Gleadall", email="andy@fullcontrol.xyz" },
     { name="Dirk Leas", email="dirk@fullcontrol.xyz" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 plotly
-pydantic
+pydantic<2.0.0
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 plotly
-pydantic<2.0.0
+pydantic
 numpy


### PR DESCRIPTION
Fix based on [Issue 31](https://github.com/FullControlXYZ/fullcontrol/issues/31) raised by [basti00](https://github.com/basti00). 

Fix Description:
I ran Pydantics version migration tool, [pydantic-bump](https://github.com/pydantic/bump-pydantic) which fixed some issues but missed all classes containing Optional[T] where the default wasn't set. Following the rule set in there migration tool I changed Optional fields to include a default of None where one wasn't set (note the first rule in their Readme). 

I used the regex expression `Optional\[[^\]]*\](?!\s*=)` to find all instances but I may have missed some, or missed some other issues (this is my first PR for this project) with migration. 

I did test to see if the Jupyter notebooks run locally, which they do but I haven't done any more comprehensive testing than running all notebooks

