### PR TITLE
Fix blank lines in GCode on Windows

### DIFF
--- a/fullcontrol/gcode/steps2gcode.py
+++ b/fullcontrol/gcode/steps2gcode.py
@@ -20,7 +20,7 @@ def gcode(steps: list, gcode_controls: GcodeControls = GcodeControls()):
         if gcode_line != None:
             state.gcode.append(gcode_line)
         state.i += 1
-    gc = os.linesep.join(state.gcode)
+    gc = '\n'.join(state.gcode)
 
     if gcode_controls.save_as != None:
         filename = gcode_controls.save_as

--- a/lab/fullcontrol/multiaxis/gcode/XYZB/steps2gcode.py
+++ b/lab/fullcontrol/multiaxis/gcode/XYZB/steps2gcode.py
@@ -18,7 +18,7 @@ def gcode(steps: list, gcode_controls: GcodeControls = GcodeControls()):
         if gcode_line != None:
             state.gcode.append(gcode_line)
         state.i += 1
-    gc = os.linesep.join(state.gcode)
+    gc = '\n'.join(state.gcode)
 
     if gcode_controls.save_as != None:
         filename = gcode_controls.save_as + \

--- a/lab/fullcontrol/multiaxis/gcode/XYZBC/steps2gcode.py
+++ b/lab/fullcontrol/multiaxis/gcode/XYZBC/steps2gcode.py
@@ -15,7 +15,7 @@ def gcode(steps: list, gcode_controls: GcodeControls = GcodeControls()):
         if gcode_line != None:
             state.gcode.append(gcode_line)
         state.i += 1
-    gc = os.linesep.join(state.gcode)
+    gc = '\n'.join(state.gcode)
 
     if gcode_controls.save_as != None:
         filename = gcode_controls.save_as + datetime.now().strftime("__%d-%m-%Y__%H-%M-%S.gcode")


### PR DESCRIPTION
**The issue:** When saving GCode on Windows (using `save_as` in `GcodeControls`), FullControl puts unnecessary blank lines between commands.

**The cause:** In the `gcode()` function, GCode lines are joined with `os.linesep`, which on Windows is `\r\n`. Python's `write` function by default replaces `\n` with `os.linesep`, so `\r\n` is written to the file as `\r\r\n`. Text editors interpret this as two line breaks, so display a blank line. Since hardcoded multiline comments are already joined with `\n`, these are translated correctly as `\r\n` when written to a file.

**The solution:** I changed `os.linesep` to `'\n'` in the `gcode()` functions. Now the GCode returned from `transform` will consistently use `\n` for line breaks, and the gcode written to the file will use the correct platform-dependent line breaks (`\r\n` on Windows). I haven't tested the code for four-axis or five-axis, but I'm assuming it will work the same.

**Here are some sample before and after snippets:**

Before

```gcode
;FLAVOR:Marlin
;TIME:0
;Filament used: 0m
;Layer height: 0
;MINX:0
;MINY:0
;MINZ:0

;MAXX:220
;MAXY:220
;MAXZ:250


; Time to print!!!!!
; GCode created with FullControl - tell us what you're printing!
; info@fullcontrol.xyz or tag FullControlXYZ on Twitter/Instagram/LinkedIn/Reddit/TikTok 


G28 ; home axes

M140 S40 ; set bed temp and continue

M105

M104 S210 ; set hotend temp and continue

M190 S40 ; set bed temp and wait

; and so on
```

After

```gcode
;FLAVOR:Marlin
;TIME:0
;Filament used: 0m
;Layer height: 0
;MINX:0
;MINY:0
;MINZ:0
;MAXX:220
;MAXY:220
;MAXZ:250

; Time to print!!!!!
; GCode created with FullControl - tell us what you're printing!
; info@fullcontrol.xyz or tag FullControlXYZ on Twitter/Instagram/LinkedIn/Reddit/TikTok 

G28 ; home axes
M140 S40 ; set bed temp and continue
M105
M104 S210 ; set hotend temp and continue
M190 S40 ; set bed temp and wait
; and so on
```