### PR TITLE
Add preheating to `"voron_zero"` printer configuration.

### DIFF
--- a/fullcontrol/gcode/printer_library/singletool/voron_zero.py
+++ b/fullcontrol/gcode/printer_library/singletool/voron_zero.py
@@ -20,6 +20,11 @@ def set_up(user_overrides: dict):
         text='; Time to print!!!!!\n; GCode created with FullControl - tell us what you\'re printing!\n; info@fullcontrol.xyz or tag FullControlXYZ on Twitter/Instagram/LinkedIn/Reddit/TikTok \n'))
     starting_procedure_steps.append(ManualGcode(text='print_start EXTRUDER=' + str(initialization_data["nozzle_temp"]) + ' BED='+str(
         initialization_data["bed_temp"]) + ' CHAMBER=' + str(initialization_data['chamber_temp'])))
+    starting_procedure_steps.append(ManualGcode(text='M105'))
+    starting_procedure_steps.append(Hotend(temp=initialization_data["nozzle_temp"], wait=False))
+    starting_procedure_steps.append(Buildplate(temp=initialization_data["bed_temp"], wait=True))
+    starting_procedure_steps.append(ManualGcode(text='M105'))
+    starting_procedure_steps.append(Hotend(temp=initialization_data["nozzle_temp"], wait=True))
     starting_procedure_steps.append(PrinterCommand(id='absolute_coords'))
     starting_procedure_steps.append(PrinterCommand(id='units_mm'))
     starting_procedure_steps.append(Extruder(relative_gcode=initialization_data["relative_e"]))


### PR DESCRIPTION
Adds preheating of extruder and bed to the starting procedure in order to avoid `Extrude below minimum temp` error.

<img width="825" alt="Screen Shot 2024-01-03 at 1 48 35 PM" src="https://github.com/FullControlXYZ/fullcontrol/assets/37542469/4d061125-d9c3-4f2a-b986-cdbb4a8c1d3e">

This error occurs when selecting `.gcode` file to run without manually preheating the extruder which often occurs when selecting a new file to run.

Prusa slicer and many other slicers therefore include a couple of lines telling the printer to wait until the extruder and bed have heated enough to the desired temperature.


https://github.com/FullControlXYZ/fullcontrol/assets/37542469/ddabd7cf-f3b1-4815-82a8-6a03b7e7c7f5

