### PR TITLE
Fix variable expansion in "Ender3 v3 se" start code

### DIFF
--- a/fullcontrol/devices/cura/settings/creality_ender3v3se.py
+++ b/fullcontrol/devices/cura/settings/creality_ender3v3se.py
@@ -1,7 +1,7 @@
 default_initial_settings = {
     "name": "Creality Ender-3 V3 SE",
     "manufacturer": "Creality3D",
-    "start_gcode": "M220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\n\nG28 ;Home\n\nM420 S1; Enable mesh leveling\n\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nM109 S[data['nozzle_temp']]\nG1 X10.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y145.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0  ;Reset Extruder\nG1 E-1.0000 F1800 ;Retract a bit\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 E0.0000 F1800 \n",
+    "start_gcode": "M220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\n\nG28 ;Home\n\nM420 S1; Enable mesh leveling\n\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nM109 S{data['nozzle_temp']}\nG1 X10.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y145.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0  ;Reset Extruder\nG1 E-1.0000 F1800 ;Retract a bit\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 E0.0000 F1800 \n",
     "end_gcode": "G91 ;Relative positioning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z10 ;Raise Z more\nG90 ;Absolute positioning\n\nG1 X0 Y{data['build_volume_y']} ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\n\nM84 X Y E ;Disable all steppers but Z\n",
     "bed_temp": 60,
     "nozzle_temp": 210,


### PR DESCRIPTION
## Reason for this change
Variable expansion is incorrect in the start code of "Ender3 v3 se".

## Description of changes
- Fixed incorrect brackets `[ ]` to braces `{ }`.

## Reproduction scenario
The problem can be reproduced by executing the code with `Cura/Creality Ender-3 V3 SE` specified in `printer_name` as shown below.

```python
import fullcontrol as fc

# create an empty list called steps
steps=[]
# add points to the list
steps.append(fc.Point(x=40,y=40,z=0.2))
steps.append(fc.Point(x=50,y=50))
steps.append(fc.Point(x=60,y=40))
# turn the extruder on or off
steps.append(fc.Extruder(on=False))
steps.append(fc.Point(x=40,y=40,z=0.4))
steps.append(fc.Extruder(on=True))
steps.append(fc.Point(x=50,y=50))
steps.append(fc.Point(x=60,y=40))

filename = 'my_design'
printer = 'Cura/Creality Ender-3 V3 SE' 
print_settings = {'extrusion_width': 0.5,'extrusion_height': 0.2, 'nozzle_temp': 210, 'bed_temp': 40, 'fan_percent': 100}

print(fc.transform(steps, 'gcode', fc.GcodeControls(printer_name=printer, initialization_data=print_settings)))

# pip install -t ./third_party -r requirements.txt --upgrade
```

<details>

<summary>Before fix</summary>

```gcode
M220 S100 ;Reset Feedrate
M221 S100 ;Reset Flowrate

G28 ;Home

M420 S1; Enable mesh leveling

G92 E0 ;Reset Extruder
G1 Z2.0 F3000 ;Move Z Axis up
G1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position
M109 S[data['nozzle_temp']]
G1 X10.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line
G1 X10.4 Y145.0 Z0.28 F5000.0 ;Move to side a little
G1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line
G92 E0  ;Reset Extruder
G1 E-1.0000 F1800 ;Retract a bit
G1 Z2.0 F3000 ;Move Z Axis up
G1 E0.0000 F1800 

; Time to print!!!!!
; Printer name: Creality Ender-3 V3 SE
; GCode created with FullControl - tell us what you're printing!
; info@fullcontrol.xyz or tag FullControlXYZ on Twitter/Instagram/LinkedIn/Reddit/TikTok 
; New terms added to the hard-coded start_gcode ensure user-overrides are implemented:
M83 ; relative extrusion
M190 S40 ; set bed temp and wait
M106 S255 ; set fan speed
;-----
; START OF PRIMER PROCEDURE
;-----
G0 F15000 X10 Y12 Z0.2
G1 F10800 X110 E4.157517
G1 Y14 E0.08315
G1 X10 E4.157517
G1 Y16 E0.08315
G1 X40 E1.247255
G1 Y40 E0.997804
;-----
; END OF PRIMER PROCEDURE
;-----

G1 X50 Y50 E0.587962
G1 X60 Y40 E0.587962
G0 F15000 X40 Z0.4
G1 F10800 X50 Y50 E0.587962
G1 X60 Y40 E0.587962
G91 ;Relative positioning
G1 E-2 F2700 ;Retract a bit
G1 E-2 Z0.2 F2400 ;Retract and raise Z
G1 X5 Y5 F3000 ;Wipe out
G1 Z10 ;Raise Z more
G90 ;Absolute positioning

G1 X0 Y220 ;Present print
M106 S0 ;Turn-off fan
M104 S0 ;Turn-off hotend
M140 S0 ;Turn-off bed

M84 X Y E ;Disable all steppers but Z

```

</details>

<details>

<summary>After fix</summary>

```gcode
M220 S100 ;Reset Feedrate
M221 S100 ;Reset Flowrate

G28 ;Home

M420 S1; Enable mesh leveling

G92 E0 ;Reset Extruder
G1 Z2.0 F3000 ;Move Z Axis up
G1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position
M109 S210
G1 X10.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line
G1 X10.4 Y145.0 Z0.28 F5000.0 ;Move to side a little
G1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line
G92 E0  ;Reset Extruder
G1 E-1.0000 F1800 ;Retract a bit
G1 Z2.0 F3000 ;Move Z Axis up
G1 E0.0000 F1800 

; Time to print!!!!!
; Printer name: Creality Ender-3 V3 SE
; GCode created with FullControl - tell us what you're printing!
; info@fullcontrol.xyz or tag FullControlXYZ on Twitter/Instagram/LinkedIn/Reddit/TikTok 
; New terms added to the hard-coded start_gcode ensure user-overrides are implemented:
M83 ; relative extrusion
M190 S40 ; set bed temp and wait
M106 S255 ; set fan speed
;-----
; START OF PRIMER PROCEDURE
;-----
G0 F15000 X10 Y12 Z0.2
G1 F10800 X110 E4.157517
G1 Y14 E0.08315
G1 X10 E4.157517
G1 Y16 E0.08315
G1 X40 E1.247255
G1 Y40 E0.997804
;-----
; END OF PRIMER PROCEDURE
;-----

G1 X50 Y50 E0.587962
G1 X60 Y40 E0.587962
G0 F15000 X40 Z0.4
G1 F10800 X50 Y50 E0.587962
G1 X60 Y40 E0.587962
G91 ;Relative positioning
G1 E-2 F2700 ;Retract a bit
G1 E-2 Z0.2 F2400 ;Retract and raise Z
G1 X5 Y5 F3000 ;Wipe out
G1 Z10 ;Raise Z more
G90 ;Absolute positioning

G1 X0 Y220 ;Present print
M106 S0 ;Turn-off fan
M104 S0 ;Turn-off hotend
M140 S0 ;Turn-off bed

M84 X Y E ;Disable all steppers but Z

```

</details>