### PR TITLE
Switch from pkg_resources to importlib.resources

### DIFF
--- a/fullcontrol/gcode/import_printer.py
+++ b/fullcontrol/gcode/import_printer.py
@@ -3,18 +3,14 @@ import json
 import os
 from copy import deepcopy
 from fullcontrol.gcode import Extruder, ManualGcode, Buildplate, Hotend, Fan
-import pkg_resources
 import fullcontrol.devices.community.singletool.base_settings as base_settings
-from importlib import import_module
-
-def load_json_from_package(package_name, resource_name):
-    resource_path = pkg_resources.resource_filename(package_name, resource_name)
-    with open(resource_path, 'r') as file:
-        return json.load(file)
+from importlib import import_module, resources
 
 
 def load_json(library, file_name):
-    return load_json_from_package('fullcontrol', f'devices/{library}/{file_name}')
+    resource = resources.files('fullcontrol') / 'devices' / library / file_name
+    with resource.open('r') as file:
+        return json.load(file)
 
 def find_terms_in_brackets(input_string):
     import re


### PR DESCRIPTION
[pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html) is deprecated, and was removed in the version of setuptools that comes with python 3.12.   So trying to use `fullcontrol` in python 3.12 give this error:

```
Python 3.12.4 (main, Jun  7 2024, 00:00:00) [GCC 14.1.1 20240607 (Red Hat 14.1.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import fullcontrol as fc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/gary/dev/fullcontrol/fullcontrol/__init__.py", line 1, in <module>
    from fullcontrol.combinations.gcode_and_visualize.common import *
  File "/home/gary/dev/fullcontrol/fullcontrol/combinations/gcode_and_visualize/common.py", line 7, in <module>
    from .classes import *
  File "/home/gary/dev/fullcontrol/fullcontrol/combinations/gcode_and_visualize/classes.py", line 3, in <module>
    import fullcontrol.gcode as gc
  File "/home/gary/dev/fullcontrol/fullcontrol/gcode/__init__.py", line 12, in <module>
    from fullcontrol.gcode.steps2gcode import gcode
  File "/home/gary/dev/fullcontrol/fullcontrol/gcode/steps2gcode.py", line 6, in <module>
    from fullcontrol.gcode.state import State
  File "/home/gary/dev/fullcontrol/fullcontrol/gcode/state.py", line 10, in <module>
    from fullcontrol.gcode.import_printer import import_printer
  File "/home/gary/dev/fullcontrol/fullcontrol/gcode/import_printer.py", line 6, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

This changes that code to use it's replacement [importlib.resources](https://docs.python.org/3/library/importlib.resources.html)